### PR TITLE
Add meta charset

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <script src="lib/dsp.js"></script>
   <script src="lib/d3.v2.js"></script>
   <script src="js/application.js"></script>


### PR DESCRIPTION
I can't play today with the demo because of this error:

![image](https://cloud.githubusercontent.com/assets/736728/7995988/406c6226-0af2-11e5-94a3-044a86331329.png)

So I added `<meta charset="utf-8">` and it worked.

:)
